### PR TITLE
Multiple graphs management fix

### DIFF
--- a/src/nodes/GraphCell.cpp
+++ b/src/nodes/GraphCell.cpp
@@ -376,6 +376,7 @@ void GraphCell::setEnabledInfo(bool b, bool changeToggler, bool callback){
 }
 
 void GraphCell::deleteMe(){
+    beforeDeletion(graphInfo, this);
     this->removeMeAndCleanup();
     
     onDeleted(graphInfo);

--- a/src/nodes/GraphCell.hpp
+++ b/src/nodes/GraphCell.hpp
@@ -24,6 +24,7 @@ class GraphCell : public CCNode {
 
         geode::Function<bool(const std::string&, GraphCell*)> canChangeNameTo;
 
+        geode::Function<void(DTGraphInfo, GraphCell*)> beforeDeletion;
         geode::Function<void(DTGraphInfo)> onDeleted;
         
         geode::Function<void(GraphCell* cell, std::optional<Session>)> onNewSession = NULL;

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -483,9 +483,9 @@ void DTGraphLayer::OnPointSelected(GraphPoint* point){
         auto pointPosConverted = m_mainLayer->convertToNodeSpace(point->convertToWorldSpace({point->getContentWidth() / 2, 0}));
 
         float heightOffset = display->getContentHeight();
-        #if defined(GEODE_IS_MOBILE)
-            heightOffset += 15;
-        #endif
+#if defined(GEODE_IS_MOBILE)
+        heightOffset += 15;
+#endif
 
         position = pointPosConverted - ccp(display->getContentWidth() / 2, heightOffset);
 

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -482,13 +482,13 @@ void DTGraphLayer::OnPointSelected(GraphPoint* point){
     if (!displaysForPoints.size()){
         auto pointPosConverted = m_mainLayer->convertToNodeSpace(point->convertToWorldSpace({point->getContentWidth() / 2, 0}));
 
-        position = pointPosConverted - ccp(
-            display->getContentWidth() / 2, 
-            display->getContentHeight()
-#if defined(GEODE_IS_MOBILE)
-                + 15
-#endif
-        );
+        float heightOffset = display->getContentHeight();
+        #if defined(GEODE_IS_MOBILE)
+            heightOffset += 15;
+        #endif
+
+        position = pointPosConverted - ccp(display->getContentWidth() / 2, heightOffset);
+
     }
     else{
         GraphPointDisplay* lowestOther = *displays.rbegin();

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -741,6 +741,13 @@ void DTGraphLayer::addGraph(const DTGraphInfo& info){
         graphNode->updateDeaths();
     };
 
+    if (graphCell->getinfo().isEnabled) {
+        for (const auto& cell : CCArrayExt<GraphCell*>(graphsScroll->m_contentLayer->getChildren())) {
+            if (cell == graphCell) continue;
+            cell->setEnabledInfo(false, true, false);
+        }
+    }
+
     graphsScroll->m_contentLayer->addChild(graphCell);
 
     graph->addGraph(info);

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -693,6 +693,8 @@ void DTGraphLayer::addGraph(const DTGraphInfo& info){
             updateGRapgCellLayout();
 
         graphNode->setInfo(cell->getinfo());
+        cell->resendSession();
+
         saveAllGraphs();
     };
 

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -712,18 +712,21 @@ void DTGraphLayer::addGraph(const DTGraphInfo& info){
         return cellWithName == nullptr || cellWithName == cell;
     };
 
-    graphCell->onDeleted = [&](DTGraphInfo info){
+    graphCell->beforeDeletion = [&](DTGraphInfo info, GraphCell* deletingCell){
+        graph->removeGraph(info.name);
+
         int indexZ = 0;
         for (const auto& child : CCArrayExt<GraphCell*>(graphsScroll->m_contentLayer->getChildren()))
         {
+            if (child == deletingCell) continue;
+
             child->setOrderPos(indexZ);
             indexZ++;
         }
+    };
 
+    graphCell->onDeleted = [&](DTGraphInfo info){
         updateGRapgCellLayout();
-
-        graph->removeGraph(info.name);
-        
         saveAllGraphs();
     };
 

--- a/src/nodes/layers/DTGraphLayer.cpp
+++ b/src/nodes/layers/DTGraphLayer.cpp
@@ -746,7 +746,7 @@ void DTGraphLayer::addGraph(const DTGraphInfo& info){
         graphNode->updateDeaths();
     };
 
-    if (graphCell->getinfo().isEnabled) {
+    if (graphCell->getinfo().isEnabled && !holdingShift) {
         for (const auto& cell : CCArrayExt<GraphCell*>(graphsScroll->m_contentLayer->getChildren())) {
             if (cell == graphCell) continue;
             cell->setEnabledInfo(false, true, false);


### PR DESCRIPTION
1) When adding new graphs, the old one stayed visible even if you didn't hold SHIFT (edit: I kinda forgot that you can show multiple graphs at the same time at first yeah)
2) When adding a new graph, immediately selecting Session type caused it to not show any session
3) When deleting a graph, the drawn content stayed there. This is still a dirty hack but should work fine. I am pretty sure there's a better fix which someone might be able to find