### PR TITLE
Fix Datetime Format

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -70,6 +70,13 @@
 			"type": "bool",
 			"default": false
 		},
+		"clock-format": {
+			"name": "Clock Format",
+			"description": "Select either 12-hour or 24-hour time display.",
+			"type": "string",
+			"default": "12-hour",
+			"one-of": ["12-hour", "24-hour"]
+		},
 		"bakcups-title":{
 			"type": "title",
 			"name": "Backups"

--- a/src/nodes/BackupCell.cpp
+++ b/src/nodes/BackupCell.cpp
@@ -1,5 +1,6 @@
 #include "BackupCell.hpp"
 #include <managers/StatsManager.hpp>
+#include <utils/DateFormatter.hpp>
 
 BackupCell* BackupCell::create(float width, const std::string& levelKey, const long long backupTime){
     auto ret = new BackupCell();
@@ -128,7 +129,7 @@ void BackupCell::onBackupLoaded(GetBackupFuture::Output out){
     gmtime_r(&timeTDate, &timeInfo);
 #endif
 
-    titleLabel->setString(fmt::format("{:%Y-%m-%d %H:%M:%S}", timeInfo).c_str());
+    titleLabel->setString(DateFormatter::format(timeInfo).c_str());
     descriptionLabel->setString(
         fmt::format(
             "Attempts: {}, Sessions: {}, Size: {:.2f} KB", 

--- a/src/nodes/BackupCell.cpp
+++ b/src/nodes/BackupCell.cpp
@@ -129,7 +129,7 @@ void BackupCell::onBackupLoaded(GetBackupFuture::Output out){
     gmtime_r(&timeTDate, &timeInfo);
 #endif
 
-    titleLabel->setString(DateFormatter::format(timeInfo).c_str());
+    titleLabel->setString(DateFormatter::timeFormat(timeInfo).c_str());
     descriptionLabel->setString(
         fmt::format(
             "Attempts: {}, Sessions: {}, Size: {:.2f} KB", 

--- a/src/nodes/SessionCell.cpp
+++ b/src/nodes/SessionCell.cpp
@@ -1,5 +1,6 @@
 #include "SessionCell.hpp"
 #include <managers/StatsManager.hpp>
+#include <utils/DateFormatter.hpp>
 
 SessionCell* SessionCell::create(float width, Session const& session){
     auto ret = new SessionCell();
@@ -27,7 +28,7 @@ bool SessionCell::init(float width, Session const& session){
 
     auto tp = std::chrono::system_clock::from_time_t(session.sessionStartDate);
 
-    std::string dateStr = fmt::format("{:%m/%d/%Y} {:%I:%M%p}", tp, tp);
+    std::string dateStr = DateFormatter::format(tp);
 
     auto dateLabel = CCLabelBMFont::create(dateStr.c_str(), "bigFont.fnt");
     dateLabel->setPosition({5, this->getContentHeight() - 7.5f});

--- a/src/nodes/SessionCell.cpp
+++ b/src/nodes/SessionCell.cpp
@@ -26,9 +26,14 @@ bool SessionCell::init(float width, Session const& session){
     bg->setContentSize((this->getContentSize() - ccp(0, 2.5f)) / bg->getScale());
     this->addChild(bg);
 
-    auto tp = std::chrono::system_clock::from_time_t(session.sessionStartDate);
+    std::tm tm{};
+    #if defined(_WIN32)
+        localtime_s(&tm, &session.sessionStartDate);
+    #else
+        localtime_r(&session.sessionStartDate, &tm);
+    #endif
 
-    std::string dateStr = DateFormatter::format(tp);
+    std::string dateStr = DateFormatter::timeFormat(tm);
 
     auto dateLabel = CCLabelBMFont::create(dateStr.c_str(), "bigFont.fnt");
     dateLabel->setPosition({5, this->getContentHeight() - 7.5f});

--- a/src/nodes/layers/DTLayer.cpp
+++ b/src/nodes/layers/DTLayer.cpp
@@ -11,6 +11,7 @@
 #include <arc/task/Yield.hpp>
 #include <arc/time/Sleep.hpp>
 
+#include <utils/DateFormatter.hpp>
 #include <utils/Settings.hpp>
 #include <nodes/layers/ChangelogPopup.hpp>
 #include <nodes/layers/TextInputPopup.hpp>
@@ -3700,7 +3701,7 @@ UpdateFuture DTLayer::onSessionDateKey(std::map<std::string, std::any> payload){
         localtime_r(&time, &tp);
     #endif
 
-    auto dateStr = fmt::format("{:%m/%d/%Y %H:%M%p}", tp);
+    auto dateStr = DateFormatter::format(tp);
 
     co_return Ok(dateStr);
 }

--- a/src/nodes/layers/DTLayer.cpp
+++ b/src/nodes/layers/DTLayer.cpp
@@ -3701,7 +3701,7 @@ UpdateFuture DTLayer::onSessionDateKey(std::map<std::string, std::any> payload){
         localtime_r(&time, &tp);
     #endif
 
-    auto dateStr = DateFormatter::format(tp);
+    auto dateStr = DateFormatter::timeFormat(tp);
 
     co_return Ok(dateStr);
 }

--- a/src/utils/DateFormatter.cpp
+++ b/src/utils/DateFormatter.cpp
@@ -1,0 +1,8 @@
+#include <utils/DateFormatter.hpp>
+#include <utils/Settings.hpp>
+
+std::string format(const tm& dateTime){
+    return Settings::is12HourClockFormat()
+        ? fmt::format("{:%m/%d/%Y %I:%M%p}", dateTime)
+        : fmt::format("{:%m/%d/%Y %H:%M}", dateTime);
+}

--- a/src/utils/DateFormatter.cpp
+++ b/src/utils/DateFormatter.cpp
@@ -1,7 +1,7 @@
 #include <utils/DateFormatter.hpp>
 #include <utils/Settings.hpp>
 
-std::string format(const tm& dateTime){
+std::string DateFormatter::timeFormat(const tm& dateTime){
     return Settings::is12HourClockFormat()
         ? fmt::format("{:%m/%d/%Y %I:%M%p}", dateTime)
         : fmt::format("{:%m/%d/%Y %H:%M}", dateTime);

--- a/src/utils/DateFormatter.hpp
+++ b/src/utils/DateFormatter.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Geode/Geode.hpp>
+
+using namespace geode::prelude;
+
+class DateFormatter {
+public:
+    static std::string format(const tm& dateTime);
+};

--- a/src/utils/DateFormatter.hpp
+++ b/src/utils/DateFormatter.hpp
@@ -6,5 +6,5 @@ using namespace geode::prelude;
 
 class DateFormatter {
 public:
-    static std::string format(const tm& dateTime);
+    static std::string timeFormat(const tm& dateTime);
 };

--- a/src/utils/Settings.cpp
+++ b/src/utils/Settings.cpp
@@ -76,3 +76,9 @@ bool Settings::getCheatDetect(){
 bool Settings::getDisablePractice(){
     return Mod::get()->getSettingValue<bool>("disable-practice-tracking");
 }
+
+bool Settings::is12HourClockFormat(){
+    auto clockFormat = Mod::get()->getSettingValue<std::string>("clock-format");
+
+    return clockFormat == "12-hour";
+}

--- a/src/utils/Settings.hpp
+++ b/src/utils/Settings.hpp
@@ -22,4 +22,5 @@ public:
     static bool getSafeMode();
     static bool getCheatDetect();
     static bool getDisablePractice();
+    static bool is12HourClockFormat();
 };


### PR DESCRIPTION
So when I opened the Death Tracker mod, I found that the time displayed incorrectly. The time showed 24-hour clock style but still has AM/PM printed out.

<img width="1120" height="130" alt="image" src="https://github.com/user-attachments/assets/fef0d36e-802a-444b-9716-6c74ad1da49f" />

So I removed the AM/PM string. As I changed the code and searched for other occurrences, I found out that the date time format were inconsistent. So I created one more util code called `DateFormatter` and add a setting to make the date time format consistent.